### PR TITLE
fix: fix typo error on docs

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,7 +1,7 @@
 ---
 title: Welcome to Poozle Docs
 sidebarTitle: Introduction
-description: "Whether you are an Poozle user or contributor, we have docs for you!"
+description: "Whether you are a Poozle user or contributor, we have docs for you!"
 ---
 
 ## For Poozle Open Source users


### PR DESCRIPTION
This fixes #1 

I found a typo error on the docs and decided to clear that up.